### PR TITLE
Add test for create a parcel without request data

### DIFF
--- a/app/views/parcels.py
+++ b/app/views/parcels.py
@@ -61,11 +61,17 @@ def add_a_parcel_order():
         400 error code if required parameter is not provided
         201 HTTP error code  if Order is created Successfully
 
-#     """
+    """
+#     Expected request data format
+    expected = {
+        "source_address": "The source Address",
+        "destination_address": "The Destination address",
+        "item": "The Item"
+    }
 
     # Check if request data is provided
     if not request.data:
-        return jsonify({'Message': "Bad format request"}), 400
+        return jsonify({'Message': "Bad format request", "Expected": expected, "status": "Failed"}), 400
 
     parcelDict = json.loads(request.data)
 
@@ -88,9 +94,8 @@ def add_a_parcel_order():
     # add new parcel order
 
     return parcels_obj.insert__a_parcel(item=item, source_address=source_address,
-                                          destination_address=destination_address,
-                                          owner_id=get_current_user_id())
-
+                                        destination_address=destination_address,
+                                        owner_id=get_current_user_id())
 
 
 @parcels_bp.route('/parcels/<parcelId>/cancel', methods=['PUT'])

--- a/tests/test_parcels.py
+++ b/tests/test_parcels.py
@@ -194,5 +194,26 @@ def test_create_a_parcel_delivery_order(test_client):
             - and a message 'You are not authorized to access this Resource
         """
         assert admin_creates_a_parcel_delivery_order.status_code == 401
-        assert json.loads(admin_creates_a_parcel_delivery_order.data.decode()) ==\
+        assert json.loads(admin_creates_a_parcel_delivery_order.data.decode()) == \
                {"message": "You are not authorized to access this Resource"}
+
+    with test_client.post('/api/v2/parcels', headers=generate_header_with_token(2)) as \
+            user_submits_request_without_data:
+        """When  user sends a post request to create a parcel delivery order
+           And user has not submitted any data along with the request
+           Then System does not create the parcel
+           And system returns an HTTP response with  
+            - a status code of 400
+            - and a message 'Bad format request and what the system expects
+        """
+        assert user_submits_request_without_data.status_code == 400
+        assert json.loads(user_submits_request_without_data.data.decode()) == \
+               {
+                   "Expected": {
+                       "destination_address": "The Destination address",
+                       "item": "The Item",
+                       "source_address": "The source Address"
+                   },
+                   "Message": "Bad format request",
+                   "status": "Failed"
+               }


### PR DESCRIPTION
 On branch ft-create_a_parcel-4129960
 Changes to be committed:
	modified:   app/views/parcels.py
	modified:   tests/test_parcels.py